### PR TITLE
Add time picker and Taiwan-specific tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     body{margin:0; font-family:var(--ff); background:#f5f7fa; color:#333; padding:var(--pad);}
     h2{margin:12px 0 16px; color:var(--primary); text-align:center;}
     form{max-width:1000px; margin:0 auto 18px; background:#fff; border-radius:var(--radius); padding:var(--pad); box-shadow:0 4px 12px rgba(0,0,0,.1);}
-    fieldset{border:1px solid #ddd; border-radius:var(--radius); padding:var(--pad); margin-bottom:20px;}
+    fieldset{border:1px solid #ddd; border-radius:var(--radius); padding:var(--pad); margin-bottom:20px; position:relative;}
     legend{font-weight:700; color:var(--primary); padding:0 8px;}
 
     .row-2{
@@ -38,6 +38,24 @@
     .picker-btn:hover{background:#dfeaff;}
 
     .muted{color:#666; font-size:.92em;}
+
+    label.chk{display:flex; align-items:center; gap:4px; font-weight:600;}
+    .expo-dates{display:flex; flex-wrap:wrap; gap:6px; margin-top:6px;}
+    .expo-dates button{
+      border:1px solid #cfe0ff;
+      background:#eef4ff;
+      color:#2d5bd1;
+      border-radius:6px;
+      padding:6px 8px;
+      cursor:pointer;
+      transition:background .2s, color .2s;
+    }
+    .expo-dates button.active{
+      background:#2d5bd1;
+      color:#fff;
+      border-color:#2d5bd1;
+      font-weight:700;
+    }
 
     /* 三顆按鈕同尺寸 */
     .btn{display:inline-block; padding:10px 18px; font-size:16px; border-radius:8px; border:none; cursor:pointer; transition:background .2s;}
@@ -67,6 +85,15 @@
     .modal .section{display:none;}
     .modal .section.active{display:block;}
 
+    .rules-btn{position:absolute; top:10px; right:10px;}
+
+    /* 時間選擇器 */
+    .time-overlay{display:none; position:fixed; inset:0; background:rgba(0,0,0,.2); align-items:center; justify-content:center; z-index:1200;}
+    .time-panel{background:#fff; width:min(260px,96vw); border-radius:12px; box-shadow:0 10px 24px rgba(0,0,0,.25); padding:12px;}
+    .time-grid{display:grid; grid-template-columns:repeat(6,1fr); gap:6px; margin-bottom:8px;}
+    .time-grid button{padding:6px; border:1px solid #ddd; border-radius:6px; background:#f7f7f7; cursor:pointer;}
+    .time-grid button.active{background:#2d5bd1; color:#fff; border-color:#2d5bd1;}
+
     /* 自製日曆（覆蓋層） */
     .cal-overlay{display:none; position:fixed; inset:0; background:rgba(0,0,0,.2); align-items:center; justify-content:center; z-index:1200;}
     .cal-panel{background:#fff; width:min(320px, 96vw); border-radius:12px; box-shadow:0 10px 24px rgba(0,0,0,.25); padding:12px;}
@@ -87,6 +114,7 @@
   <form id="mealForm" autocomplete="off">
     <fieldset>
       <legend>計算器</legend>
+      <button type="button" class="btn btn-primary rules-btn" id="openRulesBtn">查看規則與費率</button>
 
       <div class="row-2">
         <div class="field">
@@ -105,31 +133,46 @@
       <!-- 抵達：日期｜時間 -->
       <div class="row-2">
         <div class="field">
-          <div class="label">抵達（落地）日期（YYYY-MM-DD）</div>
+          <div class="label" id="arrDateLabel">抵達（落地）日期（YYYY-MM-DD）</div>
           <div class="input-group">
             <input type="text" id="arrDate" inputmode="numeric" autocomplete="off">
-            <button type="button" class="picker-btn" data-target="arrDate">📅</button>
+            <button type="button" class="picker-btn date-picker-btn" data-target="arrDate">📅</button>
           </div>
         </div>
         <div class="field">
-          <div class="label">抵達（落地）時間（HH:MM）</div>
-          <input type="text" id="arrTime" inputmode="numeric" autocomplete="off">
+          <div class="label" id="arrTimeLabel">抵達（落地）時間（HH:MM）</div>
+          <div class="input-group">
+            <input type="text" id="arrTime" inputmode="numeric" autocomplete="off">
+            <button type="button" class="picker-btn time-picker-btn" data-target="arrTime">⏰</button>
+          </div>
         </div>
       </div>
 
       <!-- 離境：日期｜時間 -->
       <div class="row-2">
         <div class="field">
-          <div class="label">離境（登機）日期（YYYY-MM-DD）</div>
+          <div class="label" id="depDateLabel">離境（登機）日期（YYYY-MM-DD）</div>
           <div class="input-group">
             <input type="text" id="depDate" inputmode="numeric" autocomplete="off">
-            <button type="button" class="picker-btn" data-target="depDate">📅</button>
+            <button type="button" class="picker-btn date-picker-btn" data-target="depDate">📅</button>
           </div>
         </div>
         <div class="field">
-          <div class="label">離境（登機）時間（HH:MM）</div>
-          <input type="text" id="depTime" inputmode="numeric" autocomplete="off">
+          <div class="label" id="depTimeLabel">離境（登機）時間（HH:MM）</div>
+          <div class="input-group">
+            <input type="text" id="depTime" inputmode="numeric" autocomplete="off">
+            <button type="button" class="picker-btn time-picker-btn" data-target="depTime">⏰</button>
+          </div>
         </div>
+      </div>
+
+      <div class="row-2">
+        <label class="chk"><input type="checkbox" id="hotelBreakfast"> 飯店供早餐</label>
+        <label class="chk"><input type="checkbox" id="expoLunch"> 展場供午餐</label>
+      </div>
+      <div class="field" id="expoDateRow" style="display:none;">
+        <div class="label">展場日期（點選）</div>
+        <div id="expoDates" class="expo-dates"></div>
       </div>
 
       <div class="muted">提示：用不到桃園機場的時間，僅看國外抵達與離開。</div>
@@ -137,7 +180,6 @@
       <div style="text-align:center; margin:16px 0;">
         <button type="button" class="btn btn-primary" id="calcBtn">計算</button>
         <button type="button" class="btn btn-secondary" id="resetBtn">重置</button>
-        <button type="button" class="btn btn-primary" id="openRulesBtn">查看規則與費率</button>
       </div>
 
       <div class="kpi" id="kpiRow" style="display:none;">
@@ -153,8 +195,12 @@
       <div>
         <h4>判別與明細</h4>
         <table id="detailTable">
-          <thead><tr><th>日期</th><th>可核給餐別</th></tr></thead>
-          <tbody><tr><td colspan="2" class="muted">請先按「計算」</td></tr></tbody>
+          <thead>
+            <tr>
+              <th>日期</th><th>早餐</th><th>午餐</th><th>晚餐</th>
+            </tr>
+          </thead>
+          <tbody><tr><td colspan="4" class="muted">請先按「計算」</td></tr></tbody>
         </table>
 
         <!-- 計價明細（顯示 單價 × 份數 = 小計） -->
@@ -231,6 +277,14 @@
     </div>
   </div>
 
+  <!-- 時間選擇器（覆蓋層） -->
+  <div class="time-overlay" id="timeOverlay" aria-hidden="true">
+    <div class="time-panel">
+      <div class="time-grid" id="hourGrid"></div>
+      <div class="time-grid" id="minGrid"></div>
+    </div>
+  </div>
+
   <script>
   (function(){
     // === 費率 ===
@@ -249,6 +303,15 @@
     const arrTime = document.getElementById('arrTime');
     const depDate = document.getElementById('depDate');
     const depTime = document.getElementById('depTime');
+    const arrDateLabel = document.getElementById('arrDateLabel');
+    const arrTimeLabel = document.getElementById('arrTimeLabel');
+    const depDateLabel = document.getElementById('depDateLabel');
+    const depTimeLabel = document.getElementById('depTimeLabel');
+
+    const hotelBreakfast = document.getElementById('hotelBreakfast');
+    const expoLunch      = document.getElementById('expoLunch');
+    const expoDateRow    = document.getElementById('expoDateRow');
+    const expoDatesDiv   = document.getElementById('expoDates');
 
     const calcBtn  = document.getElementById('calcBtn');
     const resetBtn = document.getElementById('resetBtn');
@@ -264,6 +327,22 @@
     const outCur      = document.getElementById('outCur');
     const rationaleBox= document.getElementById('rationaleBox');
     const pricingBox  = document.getElementById('pricingBox');
+
+    function updateLabels(){
+      if(countrySel.value==='TW'){
+        arrDateLabel.textContent='抵達（高鐵）日期（YYYY-MM-DD）';
+        arrTimeLabel.textContent='抵達（高鐵）時間（HH:MM）';
+        depDateLabel.textContent='離境（高鐵）日期（YYYY-MM-DD）';
+        depTimeLabel.textContent='離境（高鐵）時間（HH:MM）';
+      }else{
+        arrDateLabel.textContent='抵達（落地）日期（YYYY-MM-DD）';
+        arrTimeLabel.textContent='抵達（落地）時間（HH:MM）';
+        depDateLabel.textContent='離境（登機）日期（YYYY-MM-DD）';
+        depTimeLabel.textContent='離境（登機）時間（HH:MM）';
+      }
+    }
+    countrySel.addEventListener('change', updateLabels);
+    updateLabels();
 
     // Modal
     const rulesModal   = document.getElementById('rulesModal');
@@ -290,13 +369,41 @@
     [arrDate, depDate].forEach(el=> el.addEventListener('input', ()=>maskDate(el)));
     [arrTime, depTime].forEach(el=> el.addEventListener('input', ()=>maskTime(el)));
 
+    function generateExpoDates(){
+      expoDatesDiv.innerHTML = '';
+      if(!expoLunch.checked) return;
+      if(!/^\d{4}-\d{2}-\d{2}$/.test(arrDate.value) || !/^\d{4}-\d{2}-\d{2}$/.test(depDate.value)) return;
+      let d = dateOnly(parseLocal(arrDate.value,'00:00'));
+      const end = dateOnly(parseLocal(depDate.value,'00:00'));
+      while(d<=end){
+        const lbl = dateLabel(d);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = lbl;
+        btn.dataset.date = lbl;
+        btn.addEventListener('click', ()=> btn.classList.toggle('active'));
+        expoDatesDiv.appendChild(btn);
+        d = addDays(d,1);
+      }
+    }
+
+    expoLunch.addEventListener('change', () => {
+      expoDateRow.style.display = expoLunch.checked ? 'block' : 'none';
+      generateExpoDates();
+    });
+    [arrDate, depDate].forEach(el=> el.addEventListener('change', ()=>{ if(expoLunch.checked) generateExpoDates(); }));
+
     // ====== 自製日期選擇器（通用） ======
     const overlay = document.getElementById('calOverlay');
     const grid    = document.getElementById('calGrid');
     const titleEl = document.getElementById('calTitle');
     const prevBtn = document.getElementById('calPrev');
     const nextBtn = document.getElementById('calNext');
+    const timeOverlay = document.getElementById('timeOverlay');
+    const hourGrid = document.getElementById('hourGrid');
+    const minGrid  = document.getElementById('minGrid');
     let activeInput = null;
+    let activeTimeInput = null;
     let viewY=0, viewM=0; // month 0-11
 
     function openCalendar(targetInputId){
@@ -317,6 +424,53 @@
       overlay.style.display = 'none';
       overlay.setAttribute('aria-hidden','true');
       activeInput = null;
+    }
+    function openTimePicker(target){
+      activeTimeInput = document.getElementById(target);
+      selH=selM=null;
+      hourGrid.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
+      minGrid.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
+      const v = activeTimeInput.value;
+      if(/^\d{2}:\d{2}$/.test(v)){
+        selH=v.slice(0,2); selM=v.slice(3,5);
+        hourGrid.querySelector(`[data-h='${selH}']`)?.classList.add('active');
+        minGrid.querySelector(`[data-m='${selM}']`)?.classList.add('active');
+      }
+      timeOverlay.style.display='flex';
+      timeOverlay.setAttribute('aria-hidden','false');
+    }
+    function closeTimePicker(){
+      timeOverlay.style.display='none';
+      timeOverlay.setAttribute('aria-hidden','true');
+      activeTimeInput=null;
+    }
+    function buildTimeGrids(){
+      let h='';
+      for(let i=0;i<24;i++){ const s=String(i).padStart(2,'0'); h+=`<button data-h="${s}">${s}</button>`; }
+      hourGrid.innerHTML=h;
+      let m='';
+      for(let i=0;i<60;i++){ const s=String(i).padStart(2,'0'); m+=`<button data-m="${s}">${s}</button>`; }
+      minGrid.innerHTML=m;
+      hourGrid.querySelectorAll('button').forEach(btn=>{ btn.addEventListener('click',()=>selectTime(btn.dataset.h,null));});
+      minGrid.querySelectorAll('button').forEach(btn=>{ btn.addEventListener('click',()=>selectTime(null,btn.dataset.m));});
+    }
+    let selH=null, selM=null;
+    function selectTime(h,m){
+      if(h!==null){
+        selH=h;
+        hourGrid.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
+        hourGrid.querySelector(`[data-h='${h}']`)?.classList.add('active');
+      }
+      if(m!==null){
+        selM=m;
+        minGrid.querySelectorAll('button').forEach(b=>b.classList.remove('active'));
+        minGrid.querySelector(`[data-m='${m}']`)?.classList.add('active');
+      }
+      if(selH!==null && selM!==null && activeTimeInput){
+        activeTimeInput.value=`${selH}:${selM}`;
+        closeTimePicker();
+        selH=selM=null;
+      }
     }
     function pad2(n){ return String(n).padStart(2,'0'); }
     function renderCalendar(){
@@ -344,11 +498,20 @@
     prevBtn.addEventListener('click', ()=>{ viewM--; if(viewM<0){viewM=11; viewY--;} renderCalendar(); });
     nextBtn.addEventListener('click', ()=>{ viewM++; if(viewM>11){viewM=0; viewY++;} renderCalendar(); });
     overlay.addEventListener('click', (e)=>{ if(e.target===overlay) closeCalendar(); });
+    timeOverlay.addEventListener('click', e=>{ if(e.target===timeOverlay) closeTimePicker(); });
+    buildTimeGrids();
 
-    document.querySelectorAll('.picker-btn').forEach(btn=>{
+    document.querySelectorAll('.date-picker-btn').forEach(btn=>{
       btn.addEventListener('click', ()=>{
         const id = btn.getAttribute('data-target');
         openCalendar(id);
+      });
+    });
+
+    document.querySelectorAll('.time-picker-btn').forEach(btn=>{
+      btn.addEventListener('click', ()=>{
+        const id = btn.getAttribute('data-target');
+        openTimePicker(id);
       });
     });
 
@@ -398,31 +561,12 @@
       return '19:00–24:00 → 早餐＋午餐＋晚餐';
     }
 
-    function mealListFromMin(minIdx){
-      if (minIdx>=3) return [];
-      if (minIdx<=0) return ['早餐','午餐','晚餐'];
-      if (minIdx===1) return ['午餐','晚餐'];
-      return ['晚餐'];
-    }
-    function mealListToMax(maxIdx){
-      if (maxIdx<0)  return [];
-      if (maxIdx>=2) return ['早餐','午餐','晚餐'];
-      if (maxIdx===1) return ['早餐','午餐'];
-      return ['早餐'];
-    }
-    function addCounts(cnt, meals){
-      meals.forEach(m=>{
-        if(m==='早餐') cnt.B++;
-        if(m==='午餐') cnt.L++;
-        if(m==='晚餐') cnt.D++;
-      });
-    }
     function renderRows(rows){
       if(!rows.length){
-        detailBody.innerHTML = '<tr><td colspan="2" class="muted">無可核給餐別</td></tr>';
+        detailBody.innerHTML = '<tr><td colspan="4" class="muted">無可核給餐別</td></tr>';
         return;
       }
-      detailBody.innerHTML = rows.map(r=>`<tr><td>${r[0]}</td><td>${r[1]}</td></tr>`).join('');
+      detailBody.innerHTML = rows.map(r=>`<tr><td>${r[0]}</td><td>${r[1]}</td><td>${r[2]}</td><td>${r[3]}</td></tr>`).join('');
     }
 
     function compute(){
@@ -433,56 +577,95 @@
       rationaleBox.innerHTML = '';
       pricingBox.style.display = 'none';
       pricingBox.innerHTML = '';
-      detailBody.innerHTML = '<tr><td colspan="2" class="muted">計算中…</td></tr>';
+      detailBody.innerHTML = '<tr><td colspan="4" class="muted">計算中…</td></tr>';
 
       if(!arrDate.value || !arrTime.value || !depDate.value || !depTime.value){
         errorMsg.textContent = "請完整輸入抵達與離境的日期與時間（YYYY-MM-DD／HH:MM）。";
-        detailBody.innerHTML = '<tr><td colspan="2" class="muted">未完整輸入</td></tr>';
+        detailBody.innerHTML = '<tr><td colspan="4" class="muted">未完整輸入</td></tr>';
         return;
       }
       const arr = parseLocal(arrDate.value, arrTime.value);
       const dep = parseLocal(depDate.value, depTime.value);
       if(isNaN(arr) || isNaN(dep)){
         errorMsg.textContent = "格式不正確，請用 2025-07-10 / 10:00 這種格式。";
-        detailBody.innerHTML = '<tr><td colspan="2" class="muted">格式錯誤</td></tr>';
+        detailBody.innerHTML = '<tr><td colspan="4" class="muted">格式錯誤</td></tr>';
         return;
       }
       if(dep<=arr){
         errorMsg.textContent = "離境時間需晚於抵達時間。";
-        detailBody.innerHTML = '<tr><td colspan="2" class="muted">時間邏輯錯誤</td></tr>';
+        detailBody.innerHTML = '<tr><td colspan="4" class="muted">時間邏輯錯誤</td></tr>';
         return;
       }
 
       const r = rates[countrySel.value];
       const price = {B:r.B, L:r.L, D:r.D};
+      const fmt = n => (r.currency==='TWD' ? Math.round(n).toString() : n.toFixed(2));
 
       let cnt = {B:0, L:0, D:0};
       let rows = [];
+
+      const expoSet = new Set();
+      if(expoLunch.checked){
+        expoDatesDiv.querySelectorAll('button.active').forEach(btn => expoSet.add(btn.dataset.date));
+      }
 
       const arrMin = arrivalMinIndex(arr);
       const depMax = departureMaxIndex(dep);
 
       const arrD = dateOnly(arr), depD = dateOnly(dep);
 
+      const processDay = (d, arrIdx, depIdx, isArr)=>{
+        const label = dateLabel(d);
+        const chkExpo = expoSet.has(label);
+        const reasonLate = '抵達晚';
+        const reasonEarly = '登機早';
+        let b,l,dn;
+
+        // 早餐
+        if(0>=arrIdx && 0<=depIdx){
+          if(!isArr && hotelBreakfast.checked){
+            b='飯店供早餐';
+          }else{
+            b='✓';
+            cnt.B++;
+          }
+        }else{
+          b = (0<arrIdx) ? reasonLate : reasonEarly;
+        }
+
+        // 午餐
+        if(1>=arrIdx && 1<=depIdx){
+          if(chkExpo){
+            l='展場供午餐';
+          }else{
+            l='✓';
+            cnt.L++;
+          }
+        }else{
+          l = (1<arrIdx) ? reasonLate : reasonEarly;
+        }
+
+        // 晚餐
+        if(2>=arrIdx && 2<=depIdx){
+          dn='✓';
+          cnt.D++;
+        }else{
+          dn = (2<arrIdx) ? reasonLate : reasonEarly;
+        }
+
+        rows.push([label,b,l,dn]);
+      };
+
       if (sameDay(arrD,depD)){
-        const meals = [];
-        for(let i=Math.max(0,arrMin); i<=Math.min(2,depMax); i++) meals.push(MEALS[i]);
-        addCounts(cnt, meals);
-        rows.push([dateLabel(arrD), meals.length? meals.join('、'):'—']);
+        processDay(arrD, arrMin, depMax, true);
       }else{
-        const m1 = mealListFromMin(arrMin);
-        addCounts(cnt, m1);
-        rows.push([dateLabel(arrD), m1.length? m1.join('、'):'—']);
+        processDay(arrD, arrMin, 2, true);
         let d=addDays(arrD,1);
         while(d<depD){
-          const all=['早餐','午餐','晚餐'];
-          addCounts(cnt, all);
-          rows.push([dateLabel(d), all.join('、')]);
+          processDay(d, 0, 2, false);
           d=addDays(d,1);
         }
-        const m2 = mealListToMax(depMax);
-        addCounts(cnt, m2);
-        rows.push([dateLabel(depD), m2.length? m2.join('、'):'—']);
+        processDay(depD, 0, depMax, false);
       }
 
       const subB = cnt.B*price.B;
@@ -492,23 +675,23 @@
 
       renderRows(rows);
       kB.textContent = cnt.B; kL.textContent = cnt.L; kD.textContent = cnt.D;
-      kT.textContent = total.toFixed(2);
+      kT.textContent = fmt(total);
       kCur.textContent = r.currency;
-      totalAmt.textContent = total.toFixed(2);
+      totalAmt.textContent = fmt(total);
       outCur.textContent = r.currency;
       kpiRow.style.display = 'grid';
 
       pricingBox.innerHTML =
         `<strong>計價明細（${r.label}，${r.currency}）</strong><br>
-         早餐：${price.B} × ${cnt.B} = <strong>${subB.toFixed(2)}</strong><br>
-         午餐：${price.L} × ${cnt.L} = <strong>${subL.toFixed(2)}</strong><br>
-         晚餐：${price.D} × ${cnt.D} = <strong>${subD.toFixed(2)}</strong>`;
+         早餐：${price.B} × ${cnt.B} = <strong>${fmt(subB)}</strong><br>
+         午餐：${price.L} × ${cnt.L} = <strong>${fmt(subL)}</strong><br>
+         晚餐：${price.D} × ${cnt.D} = <strong>${fmt(subD)}</strong>`;
       pricingBox.style.display = 'block';
 
       rationaleBox.innerHTML =
         `<strong>判斷依據</strong><br>
-         抵達當日：落地時間 <strong>${timeLabel(arr)}</strong> ，屬於「${arrivalRangeText(arrMin)}」。<br>
-         離境當日：登機時間 <strong>${timeLabel(dep)}</strong> ，屬於「${departureRangeText(depMax)}」。<br>
+         抵達當日：${countrySel.value==='TW'?'高鐵時間':'落地時間'} <strong>${timeLabel(arr)}</strong> ，屬於「${arrivalRangeText(arrMin)}」。<br>
+         離境當日：${countrySel.value==='TW'?'高鐵時間':'登機時間'} <strong>${timeLabel(dep)}</strong> ，屬於「${departureRangeText(depMax)}」。<br>
          <span class="muted">（中間每一個完整在當地的日期，核給：早餐＋午餐＋晚餐）</span>`;
       rationaleBox.style.display = 'block';
     }
@@ -517,10 +700,15 @@
     calcBtn.addEventListener('click', compute);
     resetBtn.addEventListener('click', ()=>{
       [arrDate,arrTime,depDate,depTime].forEach(el=> el.value='');
-      errorMsg.textContent=""; detailBody.innerHTML='<tr><td colspan="2" class="muted">請先按「計算」</td></tr>';
+      hotelBreakfast.checked=false;
+      expoLunch.checked=false;
+      expoDateRow.style.display='none';
+      expoDatesDiv.innerHTML='';
+      errorMsg.textContent=""; detailBody.innerHTML='<tr><td colspan="4" class="muted">請先按「計算」</td></tr>';
       totalAmt.textContent="--"; kpiRow.style.display='none';
       rationaleBox.style.display='none'; rationaleBox.innerHTML='';
       pricingBox.style.display='none'; pricingBox.innerHTML='';
+      updateLabels();
     });
 
     // 規則與費率 Modal


### PR DESCRIPTION
## Summary
- reposition rules/rates button to top right of calculator
- add hour/minute picker overlay with clock buttons
- switch labels to high-speed rail when Taiwan is selected
- format TWD values without decimals
- highlight active time selections

## Testing
- `node -e "require('fs').readFileSync('index.html','utf8')" >/dev/null`


------
https://chatgpt.com/codex/tasks/task_b_688c268581788320bc3c6d5e3d165f35