### PR TITLE
Add Cambodia per diem rates to calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@
             <option value="DE">德國 🇩🇪</option>
             <option value="JP">日本 🇯🇵</option>
             <option value="VN">越南 🇻🇳</option>
+            <option value="KH">柬埔寨 🇰🇭</option>
             <option value="TW">台灣 🇹🇼</option>
           </select>
         </div>
@@ -258,6 +259,7 @@
             <tr><td>德國</td><td>USD</td><td>12</td><td>24</td><td>24</td><td>60</td></tr>
             <tr><td>日本</td><td>USD</td><td>8</td><td>16</td><td>16</td><td>40</td></tr>
             <tr><td>越南</td><td>USD</td><td>6</td><td>12</td><td>12</td><td>30</td></tr>
+            <tr><td>柬埔寨</td><td>USD</td><td>6</td><td>12</td><td>12</td><td>30</td></tr>
             <tr><td>台灣</td><td>TWD</td><td>100</td><td>200</td><td>200</td><td>500</td></tr>
           </tbody>
         </table>
@@ -295,6 +297,7 @@
       DE:{label:'德國', currency:'USD', B:12,  L:24, D:24},
       JP:{label:'日本', currency:'USD', B:8,   L:16, D:16},
       VN:{label:'越南', currency:'USD', B:6,   L:12, D:12},
+      KH:{label:'柬埔寨', currency:'USD', B:6,   L:12, D:12},
       TW:{label:'台灣', currency:'TWD', B:100, L:200, D:200}
     };
     const MEALS = ['早餐','午餐','晚餐'];


### PR DESCRIPTION
## Summary
- add Cambodia to the destination selector and rate table
- define Cambodia meal rates in the calculator configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68db938e6fa88320b124e9a3c89f8253