### PR TITLE
Add Singapore meal allowances

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
             <option value="AU">澳洲 🇦🇺</option>
             <option value="DE">德國 🇩🇪</option>
             <option value="JP">日本 🇯🇵</option>
+            <option value="SG">新加坡 🇸🇬</option>
             <option value="VN">越南 🇻🇳</option>
             <option value="KH">柬埔寨 🇰🇭</option>
             <option value="TW">台灣 🇹🇼</option>
@@ -258,6 +259,7 @@
             <tr><td>澳洲</td><td>USD</td><td>13</td><td>26</td><td>26</td><td>65</td></tr>
             <tr><td>德國</td><td>USD</td><td>12</td><td>24</td><td>24</td><td>60</td></tr>
             <tr><td>日本</td><td>USD</td><td>8</td><td>16</td><td>16</td><td>40</td></tr>
+            <tr><td>新加坡</td><td>USD</td><td>18</td><td>36</td><td>36</td><td>90</td></tr>
             <tr><td>越南</td><td>USD</td><td>6</td><td>12</td><td>12</td><td>30</td></tr>
             <tr><td>柬埔寨</td><td>USD</td><td>6</td><td>12</td><td>12</td><td>30</td></tr>
             <tr><td>台灣</td><td>TWD</td><td>100</td><td>200</td><td>200</td><td>500</td></tr>
@@ -296,6 +298,7 @@
       AU:{label:'澳洲', currency:'USD', B:13,  L:26, D:26},
       DE:{label:'德國', currency:'USD', B:12,  L:24, D:24},
       JP:{label:'日本', currency:'USD', B:8,   L:16, D:16},
+      SG:{label:'新加坡', currency:'USD', B:18,  L:36, D:36},
       VN:{label:'越南', currency:'USD', B:6,   L:12, D:12},
       KH:{label:'柬埔寨', currency:'USD', B:6,   L:12, D:12},
       TW:{label:'台灣', currency:'TWD', B:100, L:200, D:200}


### PR DESCRIPTION
## Summary
- add Singapore to the country selector with new meal allowance rates
- document the Singapore allowances in the reference table and rate map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f6ed561b10832096917cebe8532336